### PR TITLE
Fixes for KDD IPAM manifest changes

### DIFF
--- a/_includes/master/manifests/calico-kube-controllers.yaml
+++ b/_includes/master/manifests/calico-kube-controllers.yaml
@@ -139,7 +139,7 @@ spec:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS
               value: node
-            - name: ENABLED_CONTROLLERS
+            - name: DATASTORE_TYPE
               value: kubernetes
           readinessProbe:
             exec:

--- a/_includes/master/manifests/rbac.yaml
+++ b/_includes/master/manifests/rbac.yaml
@@ -137,6 +137,12 @@ rules:
 {{- if eq .Values.datastore "kdd" }}
       # Calico stores some configuration information in node annotations.
       - update
+  # The Calico IPAM migration needs to get daemonsets
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+    verbs:
+      - get
   # Watch for changes to Kubernetes NetworkPolicies.
   - apiGroups: ["networking.k8s.io"]
     resources:

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
@@ -70,6 +70,9 @@ rules:
       - ippools
       - networkpolicies
       - hostendpoints
+      - ipamblocks
+      - blockaffinities
+      - ipamhandles
     verbs:
       - create
       - get


### PR DESCRIPTION
## add rbac roles for calicoctl
deliberately omitted `ipamconfigs` as that is an internal resource that the user should never have to interact with

## kdd calico-kube-controllers
fixed a typo